### PR TITLE
Added a feature to upload a custom background paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
         /></span>
       </button>
       <h1>Text to Handwriting</h1>
-      <section style="font-size: 1rem; padding: 20px 0px;">
+      <section style="font-size: 1rem; padding: 20px 0px">
         <div>
           Hey everyone! Thank you for supporting Text to Handwriting 🎉
           <ul class="info-ul">
@@ -139,7 +139,7 @@
           <div class="display-flex output-grid responsive-flex">
             <div class="flex-1 page-container-super">
               <div>
-                <h2 style="margin-top: 0px;">Input</h2>
+                <h2 style="margin-top: 0px">Input</h2>
                 <label class="block" for="note">Type/Paste text here</label>
               </div>
 
@@ -178,7 +178,7 @@
                 <button
                   id="draw-diagram-button"
                   type="button"
-                  style="font-size: 0.9rem; margin-top: 5px;"
+                  style="font-size: 0.9rem; margin-top: 5px"
                   class="draw-button"
                 >
                   Draw <small>(Beta)</small>
@@ -188,9 +188,9 @@
 
             <div class="customization-col">
               <!-- Handwriting Font -->
-              <div style="padding: 5px 0px 5px 0px;">
+              <div style="padding: 5px 0px 5px 0px">
                 <b>Customizations</b> <small>(Optional)</small>
-                <p style="font-size: 0.8rem;">
+                <p style="font-size: 0.8rem">
                   <em
                     >Note: Few changes may reflect only in the generated image
                     and not in the preview</em
@@ -208,25 +208,20 @@
                     <select id="handwriting-font">
                       <option
                         selected
-                        style="font-family: 'Homemade Apple';"
+                        style="font-family: 'Homemade Apple'"
                         value="'Homemade Apple', cursive"
                       >
                         Homemade Apple
                       </option>
-                      <option value="Hindi_Font">
-                        Kruti-dev(Hindi)
-                      </option>
+                      <option value="Hindi_Font">Kruti-dev(Hindi)</option>
                       <option
-                        style="font-family: 'Caveat', cursive; font-size: 13pt;"
+                        style="font-family: 'Caveat', cursive; font-size: 13pt"
                         value="'Caveat', cursive"
                       >
                         Caveat
                       </option>
                       <option
-                        style="
-                          font-family: 'Liu Jian Mao Cao';
-                          font-size: 13pt;
-                        "
+                        style="font-family: 'Liu Jian Mao Cao'; font-size: 13pt"
                         value="'Liu Jian Mao Cao', cursive"
                       >
                         Liu Jian Mao Cao
@@ -237,7 +232,7 @@
                     <label class="block" for="font-file"
                       >Upload your handwriting font <small>(Beta)</small>&nbsp;
                       <a
-                        style="font-size: 1.1rem;"
+                        style="font-size: 1.1rem"
                         title="How to add your own handwriting"
                         href="#how-to-add-handwriting"
                       >
@@ -370,7 +365,7 @@
                     <label
                       title="Paper Curve (Yet to be implemented)"
                       class="switch-toggle outer"
-                      style="cursor: not-allowed !important;"
+                      style="cursor: not-allowed !important"
                     >
                       <input
                         aria-checked="false"
@@ -384,6 +379,21 @@
                 </div>
               </fieldset>
 
+              <!-- UPLOAD A CUSTOM PAPER TO WRITE ON -->
+              <fieldset>
+                <legend>Upload a custom paper</legend>
+                <div class="upload-paper-container">
+                  <label class="block" for="paper-file"
+                    >Upload paper of the chosen page size</label
+                  >
+                  <input
+                    accept=".jpg, .jpeg, .png"
+                    type="file"
+                    id="paper-file"
+                  />
+                </div>
+              </fieldset>
+
               <!-- GENERATE IMAGE BUTTONS -->
               <hr
                 style="
@@ -391,7 +401,7 @@
                   width: 80%;
                 "
               />
-              <div style="text-align: center; padding: 30px 0px;">
+              <div style="text-align: center; padding: 30px 0px">
                 <button
                   type="submit"
                   data-testid="generate-image-button"
@@ -408,10 +418,10 @@
       <!-- OUTPUT -->
       <section>
         <h2 id="output-header">Output</h2>
-        <div id="output" class="output" style="text-align: center;">
+        <div id="output" class="output" style="text-align: center">
           Click "Generate Image" Button to generate new image.
         </div>
-        <div style="text-align: center; padding: 30px;">
+        <div style="text-align: center; padding: 30px">
           <button class="imp-button" id="download-as-pdf-button">
             Download All Images as PDF
           </button>
@@ -461,7 +471,7 @@
           <a href="https://www.patreon.com/bePatron?u=31891872">
             <img
               loading="lazy"
-              style="border-radius: 4px;"
+              style="border-radius: 4px"
               alt="Buy me a Coffee Button"
               width="200"
               src="https://c5.patreon.com/external/logo/become_a_patron_button.png"
@@ -471,7 +481,7 @@
           <a href="https://www.buymeacoffee.com/saurabhdaware">
             <img
               loading="lazy"
-              style="border-radius: 4px;"
+              style="border-radius: 4px"
               alt="Buy me a Coffee Button"
               width="200"
               src="https://cdn.buymeacoffee.com/buttons/default-yellow.png"
@@ -483,7 +493,7 @@
       <section id="github-contributors">
         <h2>👫 GitHub Contributors</h2>
         <div class="project-contributors" id="project-contributors"></div>
-        <div style="padding: 20px 5px;">
+        <div style="padding: 20px 5px">
           Text-to-Handwriting is an open-source tool built with HTML, CSS, and
           JavaScript! <br />You can check out
           <a
@@ -524,7 +534,7 @@
         </div>
       </section>
     </main>
-    <footer style="padding: 40px 0px 10px 0px;">
+    <footer style="padding: 40px 0px 10px 0px">
       Thank you for using Text to Handwriting! If you have any
       questions/suggestions/feedback, you can drop me a message on
       <a href="https://twitter.com/saurabhcodes">Twitter @saurabhcodes</a>
@@ -546,20 +556,20 @@
       <div class="display-flex responsive-flex">
         <canvas
           id="diagram-canvas"
-          style="background-color: #fff;"
+          style="background-color: #fff"
           height="300px"
           width="600px"
         ></canvas>
         <div class="flex-1 buttons-container padding-around">
           <button
             id="add-to-paper-button"
-            style="margin-top: 5px; margin-bottom: 5px;"
+            style="margin-top: 5px; margin-bottom: 5px"
           >
             Add to Paper
           </button>
           <button
             id="draw-download-button"
-            style="margin-top: 5px; margin-bottom: 5px;"
+            style="margin-top: 5px; margin-bottom: 5px"
           >
             Download Image
           </button>
@@ -575,7 +585,7 @@
           <button
             id="clear-draw-canvas"
             class="blue-button"
-            style="background-color: #f30; color: #fff;"
+            style="background-color: #f30; color: #fff"
           >
             Clear Canvas
           </button>
@@ -609,7 +619,7 @@
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
           fill="currentColor"
-          style="transform-origin: 130px 106px;"
+          style="transform-origin: 130px 106px"
           class="octo-arm"
         ></path>
         <path

--- a/js/app.mjs
+++ b/js/app.mjs
@@ -1,4 +1,4 @@
-import { addFontFromFile, formatText } from './utils/helpers.mjs';
+import { addFontFromFile, formatText, addPaperFromFile } from './utils/helpers.mjs';
 import { generateImages, downloadAsPDF } from './generate-images.mjs';
 import { setInkColor, toggleDrawCanvas } from './utils/draw.mjs';
 
@@ -108,6 +108,10 @@ const EVENT_MAP = {
   '.page-a .paper-content': {
     on: 'paste',
     action: formatText
+  },
+  '#paper-file': {
+    on: 'change',
+    action: (e) => addPaperFromFile(e.target.files[0])
   }
 };
 

--- a/js/generate-images.mjs
+++ b/js/generate-images.mjs
@@ -16,7 +16,8 @@ async function convertDIVToImage() {
   const options = {
     scrollX: 0,
     scrollY: -window.scrollY,
-    scale: document.querySelector('#resolution').value
+    scale: document.querySelector('#resolution').value,
+    useCORS: true
   };
 
   /** Function html2canvas comes from a library html2canvas which is included in the index.html */

--- a/js/utils/helpers.mjs
+++ b/js/utils/helpers.mjs
@@ -50,4 +50,9 @@ function formatText(event) {
   document.execCommand('insertHTML', false, text);
 }
 
-export { isMobile, addFontFromFile, createPDF, formatText };
+function addPaperFromFile(file) {
+  var tmppath = URL.createObjectURL(file);
+  pageEl.style.backgroundImage = `url(${tmppath})`;
+}
+
+export { isMobile, addFontFromFile, createPDF, formatText, addPaperFromFile };


### PR DESCRIPTION
Fixes #32 

I have added an option to upload a custom background paper as a .jpg, .jpeg or a .png file. Following are two screen shots showing 
how this feature affects the preview and the generated images (using the three different effects - Shadows, Scanner and no effect)

![Preview](https://user-images.githubusercontent.com/58681405/94912129-d050f600-04c4-11eb-81d7-54c43b8b6c97.png)

![Images generated using the three effects](https://user-images.githubusercontent.com/58681405/94912150-d941c780-04c4-11eb-805f-856a67952fc4.png)

Resolves #32